### PR TITLE
Database migration

### DIFF
--- a/dependencies/cmake/spdlog/CMakeLists.txt
+++ b/dependencies/cmake/spdlog/CMakeLists.txt
@@ -1,8 +1,10 @@
 include(FetchContent)
 
-add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
-
 FetchContent_Declare(spdlog
         GIT_REPOSITORY https://github.com/gabime/spdlog.git
         GIT_TAG v1.10.0)
 FetchContent_MakeAvailable(spdlog)
+
+if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    target_compile_definitions(spdlog PUBLIC -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
+endif ()

--- a/etc/config.yaml.example
+++ b/etc/config.yaml.example
@@ -1,3 +1,7 @@
+# the hostname of node which is running cranectld
+ControlMachine: cn15
+# the name of this cluster
+ClusterName: pkuhpc_test
 # the ip address of control machine
 CraneCtldListenAddr: 0.0.0.0
 # the port of control machine to listen
@@ -9,13 +13,12 @@ CraneCtldLogFile: /tmp/cranectld/cranectld.log
 # Determines whether the cranectld is running in the background
 CraneCtldForeground: true
 
-# username and password of mysql
-DbUser: root
+# information of mongodb
+DbUser: admin
 DbPassword: "123456"
-
-# username and password of mongodb
-MongodbUser: crane
-MongodbPassword: 123456!!
+DbHost: localhost
+DbPort: 27017
+DbName: crane_db
 
 # debug level of craned
 CranedDebugLevel: trace
@@ -34,4 +37,3 @@ Nodes:
 Partitions:
   - name: CPU
     nodes: "cn[15-18]"
-    AllowUsers: root

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -218,10 +218,9 @@ struct Config {
 
   std::string DbUser;
   std::string DbPassword;
-  std::string MongodbUser;
-  std::string MongodbPassword;
-  std::string MongodbHost;
-  std::string MongodbPort;
+  std::string DbHost;
+  std::string DbPort;
+  std::string DbName;
 };
 
 }  // namespace Ctld

--- a/src/CraneCtld/DbClient.h
+++ b/src/CraneCtld/DbClient.h
@@ -21,61 +21,6 @@ using bsoncxx::builder::stream::document;
 
 namespace Ctld {
 
-class MariadbClient {
- public:
-  MariadbClient() = default;
-
-  ~MariadbClient();
-
-  bool Init();
-
-  void SetUserAndPwd(const std::string& username, const std::string& password);
-
-  bool Connect();
-
-  bool GetMaxExistingJobId(uint64_t* job_id);
-
-  bool GetLastInsertId(uint64_t* id);
-
-  bool InsertJob(uint64_t* job_db_inx, uint64_t mod_timestamp,
-                 const std::string& account, uint32_t cpu,
-                 uint64_t memory_bytes, const std::string& job_name,
-                 const std::string& env, uint32_t id_job, uid_t id_user,
-                 uid_t id_group, const std::string& nodelist,
-                 uint32_t nodes_alloc, const std::string& node_inx,
-                 const std::string& partition_name, uint32_t priority,
-                 uint64_t submit_timestamp, const std::string& script,
-                 uint32_t state, uint32_t timelimit,
-                 const std::string& work_dir,
-                 const crane::grpc::TaskToCtld& task_to_ctld);
-
-  bool FetchJobRecordsWithStates(
-      std::list<Ctld::TaskInCtld>* task_list,
-      const std::list<crane::grpc::TaskStatus>& states);
-
-  bool UpdateJobRecordField(uint64_t job_db_inx, const std::string& field_name,
-                            const std::string& val);
-
-  bool UpdateJobRecordFields(uint64_t job_db_inx,
-                             const std::list<std::string>& field_name,
-                             const std::list<std::string>& val);
-
- private:
-  void PrintError_(const std::string& msg) {
-    CRANE_ERROR("{}: {}\n", msg, mysql_error(m_conn));
-  }
-
-  void PrintError_(const char* msg) {
-    CRANE_ERROR("{}: {}\n", msg, mysql_error(m_conn));
-  }
-
-  MYSQL* m_conn{nullptr};
-  const std::string m_db_name{"crane_db"};
-
-  std::string m_user;
-  std::string m_psw;
-};
-
 class MongodbClient {
  public:
   enum EntityType {
@@ -99,9 +44,7 @@ class MongodbClient {
     RelationalOperator relateOperator;
     std::string value;
   };
-  MongodbClient() = default;
-
-  ~MongodbClient();
+  MongodbClient() = default;  // Mongodb-c++ don't need to close the connection
 
   bool Connect();
 
@@ -164,23 +107,23 @@ class MongodbClient {
                                   crane::grpc::ModifyEntityRequest::Type type);
 
  private:
-  void PrintError_(const char* msg) { CRANE_ERROR("MongodbError: {}\n", msg); }
+  static void PrintError_(const char* msg) {
+    CRANE_ERROR("MongodbError: {}\n", msg);
+  }
 
-  const std::string m_db_name{"crane_db"};
+  std::string m_db_name;
   const std::string m_job_collection_name{"job_table"};
   const std::string m_account_collection_name{"acct_table"};
   const std::string m_user_collection_name{"user_table"};
   const std::string m_qos_collection_name{"qos_table"};
 
-  mongocxx::instance* m_dbInstance{nullptr};
-  mongocxx::client* m_client = {nullptr};
-  mongocxx::database* m_database = {nullptr};
-  mongocxx::collection *m_job_collection{nullptr},
-      *m_account_collection{nullptr}, *m_user_collection{nullptr},
-      *m_qos_collection{nullptr};
+  std::unique_ptr<mongocxx::instance> m_dbInstance;
+  std::unique_ptr<mongocxx::client> m_client;
+  std::unique_ptr<mongocxx::database> m_database;
+  std::shared_ptr<mongocxx::collection> m_job_collection, m_account_collection,
+      m_user_collection, m_qos_collection;
 };
 
 }  // namespace Ctld
 
-inline std::unique_ptr<Ctld::MariadbClient> g_db_client;
-inline std::unique_ptr<Ctld::MongodbClient> g_mongodb_client;
+inline std::unique_ptr<Ctld::MongodbClient> g_db_client;

--- a/src/Craned/Craned.cpp
+++ b/src/Craned/Craned.cpp
@@ -30,7 +30,7 @@ void ParseConfig(int argc, char** argv) {
 
       if (config["CranedListen"])
         g_config.ListenConf.CranedListenAddr =
-            config["listen"].as<std::string>();
+            config["CranedListen"].as<std::string>();
       else
         g_config.ListenConf.CranedListenAddr = "0.0.0.0";
 


### PR DESCRIPTION
1.migrate mariadb to mongodb.
2.the original mariadb-c code is merged into the mariadb_connector_c_test. 3.reorganize the installation guide markdown file. 4.when the mongodb database does not exist, a new database will be created. 5.replace the mongodb-cxx-driver deprecated interface. User can customize the database name in config.yaml.