### PR TITLE
cqueue和cinfo添加flag：

### DIFF
--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -231,7 +231,7 @@ message QueryJobsInPartitionRequest {
   repeated string partitions = 1;
   bool find_all = 2;
   repeated uint32 task_ids = 3;
-  TaskStatus task_status = 4;
+  repeated TaskStatus task_status = 4;
   repeated string task_names =5;
 }
 

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -229,10 +229,9 @@ message QueryTaskIdFromPortForwardReply{
 
 message QueryJobsInPartitionRequest {
   repeated string partitions = 1;
-  bool find_all = 2;
-  repeated uint32 task_ids = 3;
-  repeated TaskStatus task_status = 4;
-  repeated string task_names =5;
+  repeated uint32 task_ids = 2;
+  repeated TaskStatus task_status = 3;
+  repeated string task_names =4;
 }
 
 message QueryJobsInPartitionReply {
@@ -240,10 +239,8 @@ message QueryJobsInPartitionReply {
   repeated TaskStatus task_status = 2;
   repeated string allocated_craneds = 3;
   repeated uint32 task_ids = 4;
-  bool ok = 5;
-  string reason = 6;
-  repeated string task_partitions=7;
-  repeated string task_names=8;
+  repeated string task_partitions=5;
+  repeated string task_names=6;
 }
 
 message QueryJobsInfoRequest {

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -228,8 +228,11 @@ message QueryTaskIdFromPortForwardReply{
 }
 
 message QueryJobsInPartitionRequest {
-  string partition = 1;
+  repeated string partitions = 1;
   bool find_all = 2;
+  repeated uint32 task_ids = 3;
+  TaskStatus task_status = 4;
+  repeated string task_names =5;
 }
 
 message QueryJobsInPartitionReply {
@@ -237,6 +240,10 @@ message QueryJobsInPartitionReply {
   repeated TaskStatus task_status = 2;
   repeated string allocated_craneds = 3;
   repeated uint32 task_ids = 4;
+  bool ok = 5;
+  string reason = 6;
+  repeated string task_partitions=7;
+  repeated string task_names=8;
 }
 
 message QueryJobsInfoRequest {
@@ -343,12 +350,17 @@ message MigrateSshProcToCgroupReply {
 }
 
 message QueryClusterInfoRequest {
-
+  repeated string partitions=1;
+  repeated string nodes=2;
+  repeated CranedState states=3;
+  bool query_down_nodes=4;
+  bool query_responding_nodes=5;
 }
 
 message QueryClusterInfoReply {
   bool ok = 1;
   repeated PartitionCranedInfo partition_craned = 2;
+  string reason = 3;
 }
 
 // Todo: Divide service into two parts: one for Craned and one for Crun

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -169,6 +169,7 @@ message PartitionCranedInfo {
   string name = 1;
   PartitionState state = 2;
   repeated CranedListRegexOfState common_craned_state_list = 3;
+    string partition_craned_list_regex =4;
 }
 
 enum EntityType {

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -462,7 +462,7 @@ CranedMetaContainerSimpleImpl::QueryClusterInfo(
     down_craned_list->set_state(crane::grpc::CranedState::CRANE_DOWN);
 
     std::list<std::string> idle_craned_name_list, mix_craned_name_list,
-        alloc_craned_name_list, down_craned_name_list;
+        alloc_craned_name_list, down_craned_name_list, total_name_list;
 
     for (auto&& [craned_index, craned_meta] : part_meta.craned_meta_map) {
       if (!request->nodes().empty()) {
@@ -557,6 +557,14 @@ CranedMetaContainerSimpleImpl::QueryClusterInfo(
         util::HostNameListToStr(alloc_craned_name_list));
     down_craned_list->set_craned_list_regex(
         util::HostNameListToStr(down_craned_name_list));
+
+    total_name_list.splice(total_name_list.begin(), down_craned_name_list);
+    total_name_list.splice(total_name_list.begin(), idle_craned_name_list);
+    total_name_list.splice(total_name_list.begin(), mix_craned_name_list);
+    total_name_list.splice(total_name_list.begin(), alloc_craned_name_list);
+    total_name_list.unique();
+    part_craned_info->set_partition_craned_list_regex(
+        util::HostNameListToStr(total_name_list));
   }
 
   return reply;

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -427,17 +427,28 @@ CranedMetaContainerSimpleImpl::QueryClusterInfo(
   crane::grpc::QueryClusterInfoReply reply;
   auto* partition_craned_list = reply.mutable_partition_craned();
 
+  std::unordered_set<std::string> req_partitions;
+  std::unordered_set<std::string> req_nodes;
+  std::unordered_set<int> req_states;
+
+  if (!request.partitions().empty()) {
+    std::copy(request.partitions().begin(), request.partitions().end(),
+              std::inserter(req_partitions, req_partitions.begin()));
+  }
+  if (!request.nodes().empty()) {
+    std::copy(request.nodes().begin(), request.nodes().end(),
+              std::inserter(req_nodes, req_nodes.begin()));
+  }
+  if (!request.states().empty()) {
+    std::copy(request.states().begin(), request.states().end(),
+              std::inserter(req_states, req_states.begin()));
+  }
+
   for (auto&& [part_id, part_meta] : partition_metas_map_) {
-    if (!request.partitions().empty()) {
-      bool found = false;
-      for (const auto& name : request.partitions()) {
-        if (part_meta.partition_global_meta.name == name) {
-          found = true;
-          break;
-        }
-      }
-      if (!found) continue;
-    }
+    if (!request.partitions().empty() &&
+        req_partitions.find(part_meta.partition_global_meta.name) ==
+            req_partitions.end())
+      continue;
 
     auto* part_craned_info = partition_craned_list->Add();
     part_craned_info->set_name(part_meta.partition_global_meta.name);
@@ -465,89 +476,48 @@ CranedMetaContainerSimpleImpl::QueryClusterInfo(
         alloc_craned_name_list, down_craned_name_list, total_name_list;
 
     for (auto&& [craned_index, craned_meta] : part_meta.craned_meta_map) {
-      if (!request.nodes().empty()) {
-        bool found = false;
-        for (const auto& node : request.nodes()) {
-          if (node == craned_meta.static_meta.hostname) {
-            found = true;
-            break;
-          }
-        }
-        if (!found) continue;
-      }
+      if (!request.nodes().empty() &&
+          req_nodes.find(craned_meta.static_meta.hostname) ==
+              req_partitions.end())
+        continue;
 
       auto& alloc_res_total = craned_meta.res_total.allocatable_resource;
       auto& alloc_res_in_use = craned_meta.res_in_use.allocatable_resource;
       auto& alloc_res_avail = craned_meta.res_avail.allocatable_resource;
 
-      if (!request.states().empty()) {
-        if (craned_meta.alive) {
-          if (request.query_down_nodes() &&
-              part_meta.partition_global_meta.alive_craned_cnt > 0)
-            continue;
-          if (alloc_res_in_use.cpu_count == 0 &&
-              alloc_res_in_use.memory_bytes == 0) {
-            if (std::find(request.states().begin(), request.states().end(),
-                          crane::grpc::CranedState::CRANE_IDLE) ==
-                request.states().end())
-              continue;
-            idle_craned_list->set_craned_num(idle_craned_list->craned_num() +
-                                             1);
-            idle_craned_name_list.emplace_back(
-                craned_meta.static_meta.hostname);
-          } else if (alloc_res_avail.cpu_count == 0 &&
-                     alloc_res_avail.memory_bytes == 0) {
-            if (std::find(request.states().begin(), request.states().end(),
-                          crane::grpc::CranedState::CRANE_ALLOC) ==
-                request.states().end())
-              continue;
-            alloc_craned_list->set_craned_num(alloc_craned_list->craned_num() +
-                                              1);
-            alloc_craned_name_list.emplace_back(
-                craned_meta.static_meta.hostname);
-          } else {
-            if (std::find(request.states().begin(), request.states().end(),
-                          crane::grpc::CranedState::CRANE_MIX) ==
-                request.states().end())
-              continue;
-            mix_craned_list->set_craned_num(mix_craned_list->craned_num() + 1);
-            mix_craned_name_list.emplace_back(craned_meta.static_meta.hostname);
-          }
-        } else {
-          if (request.query_responding_nodes()) continue;
-          if (std::find(request.states().begin(), request.states().end(),
-                        crane::grpc::CranedState::CRANE_DOWN) ==
-              request.states().end())
-            continue;
-          down_craned_list->set_craned_num(down_craned_list->craned_num() + 1);
-          down_craned_name_list.emplace_back(craned_meta.static_meta.hostname);
-        }
+      crane::grpc::CranedState state;
+      if (craned_meta.alive) {
+        if (request.query_down_nodes() &&
+            part_meta.partition_global_meta.alive_craned_cnt > 0)
+          continue;
+        if (alloc_res_in_use.cpu_count == 0 &&
+            alloc_res_in_use.memory_bytes == 0)
+          state = crane::grpc::CranedState::CRANE_IDLE;
+        else if (alloc_res_avail.cpu_count == 0 &&
+                 alloc_res_avail.memory_bytes == 0)
+          state = crane::grpc::CranedState::CRANE_ALLOC;
+        else
+          state = crane::grpc::CranedState::CRANE_MIX;
       } else {
-        if (craned_meta.alive) {
-          if (request.query_down_nodes() &&
-              part_meta.partition_global_meta.alive_craned_cnt > 0)
-            continue;
-          if (alloc_res_in_use.cpu_count == 0 &&
-              alloc_res_in_use.memory_bytes == 0) {
-            idle_craned_list->set_craned_num(idle_craned_list->craned_num() +
-                                             1);
-            idle_craned_name_list.emplace_back(
-                craned_meta.static_meta.hostname);
-          } else if (alloc_res_avail.cpu_count == 0 &&
-                     alloc_res_avail.memory_bytes == 0) {
-            alloc_craned_list->set_craned_num(alloc_craned_list->craned_num() +
-                                              1);
-            alloc_craned_name_list.emplace_back(
-                craned_meta.static_meta.hostname);
-          } else {
-            mix_craned_list->set_craned_num(mix_craned_list->craned_num() + 1);
-            mix_craned_name_list.emplace_back(craned_meta.static_meta.hostname);
-          }
-        } else {
-          if (request.query_responding_nodes()) continue;
-          down_craned_list->set_craned_num(down_craned_list->craned_num() + 1);
-          down_craned_name_list.emplace_back(craned_meta.static_meta.hostname);
-        }
+        if (request.query_responding_nodes()) continue;
+        state = crane::grpc::CranedState::CRANE_DOWN;
+      }
+
+      if (!request.states().empty() &&
+          req_states.find(state) == req_states.end())
+        continue;
+      if (state == crane::grpc::CranedState::CRANE_IDLE) {
+        idle_craned_list->set_craned_num(idle_craned_list->craned_num() + 1);
+        idle_craned_name_list.emplace_back(craned_meta.static_meta.hostname);
+      } else if (state == crane::grpc::CranedState::CRANE_ALLOC) {
+        alloc_craned_list->set_craned_num(alloc_craned_list->craned_num() + 1);
+        alloc_craned_name_list.emplace_back(craned_meta.static_meta.hostname);
+      } else if (state == crane::grpc::CranedState::CRANE_MIX) {
+        mix_craned_list->set_craned_num(mix_craned_list->craned_num() + 1);
+        mix_craned_name_list.emplace_back(craned_meta.static_meta.hostname);
+      } else {
+        down_craned_list->set_craned_num(down_craned_list->craned_num() + 1);
+        down_craned_name_list.emplace_back(craned_meta.static_meta.hostname);
       }
     }
 

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -422,15 +422,15 @@ CranedMetaContainerSimpleImpl::QueryPartitionInfo(
 
 crane::grpc::QueryClusterInfoReply
 CranedMetaContainerSimpleImpl::QueryClusterInfo(
-    const crane::grpc::QueryClusterInfoRequest* request) {
+    const crane::grpc::QueryClusterInfoRequest& request) {
   LockGuard guard(mtx_);
   crane::grpc::QueryClusterInfoReply reply;
   auto* partition_craned_list = reply.mutable_partition_craned();
 
   for (auto&& [part_id, part_meta] : partition_metas_map_) {
-    if (!request->partitions().empty()) {
+    if (!request.partitions().empty()) {
       bool found = false;
-      for (const auto& name : request->partitions()) {
+      for (const auto& name : request.partitions()) {
         if (part_meta.partition_global_meta.name == name) {
           found = true;
           break;
@@ -465,9 +465,9 @@ CranedMetaContainerSimpleImpl::QueryClusterInfo(
         alloc_craned_name_list, down_craned_name_list, total_name_list;
 
     for (auto&& [craned_index, craned_meta] : part_meta.craned_meta_map) {
-      if (!request->nodes().empty()) {
+      if (!request.nodes().empty()) {
         bool found = false;
-        for (const auto& node : request->nodes()) {
+        for (const auto& node : request.nodes()) {
           if (node == craned_meta.static_meta.hostname) {
             found = true;
             break;
@@ -480,15 +480,15 @@ CranedMetaContainerSimpleImpl::QueryClusterInfo(
       auto& alloc_res_in_use = craned_meta.res_in_use.allocatable_resource;
       auto& alloc_res_avail = craned_meta.res_avail.allocatable_resource;
 
-      if (!request->states().empty()) {
+      if (!request.states().empty()) {
         if (craned_meta.alive) {
-          if (request->query_down_nodes() &&
+          if (request.query_down_nodes() &&
               part_meta.partition_global_meta.alive_craned_cnt > 0)
             continue;
           if (alloc_res_in_use.cpu_count == 0 &&
               alloc_res_in_use.memory_bytes == 0) {
-            if (std::find(request->states().begin(), request->states().end(),
-                          0) == request->states().end())
+            if (std::find(request.states().begin(), request.states().end(),
+                          0) == request.states().end())
               continue;
             idle_craned_list->set_craned_num(idle_craned_list->craned_num() +
                                              1);
@@ -496,31 +496,31 @@ CranedMetaContainerSimpleImpl::QueryClusterInfo(
                 craned_meta.static_meta.hostname);
           } else if (alloc_res_avail.cpu_count == 0 &&
                      alloc_res_avail.memory_bytes == 0) {
-            if (std::find(request->states().begin(), request->states().end(),
-                          2) == request->states().end())
+            if (std::find(request.states().begin(), request.states().end(),
+                          2) == request.states().end())
               continue;
             alloc_craned_list->set_craned_num(alloc_craned_list->craned_num() +
                                               1);
             alloc_craned_name_list.emplace_back(
                 craned_meta.static_meta.hostname);
           } else {
-            if (std::find(request->states().begin(), request->states().end(),
-                          1) == request->states().end())
+            if (std::find(request.states().begin(), request.states().end(),
+                          1) == request.states().end())
               continue;
             mix_craned_list->set_craned_num(mix_craned_list->craned_num() + 1);
             mix_craned_name_list.emplace_back(craned_meta.static_meta.hostname);
           }
         } else {
-          if (request->query_responding_nodes()) continue;
-          if (std::find(request->states().begin(), request->states().end(),
-                        3) == request->states().end())
+          if (request.query_responding_nodes()) continue;
+          if (std::find(request.states().begin(), request.states().end(), 3) ==
+              request.states().end())
             continue;
           down_craned_list->set_craned_num(down_craned_list->craned_num() + 1);
           down_craned_name_list.emplace_back(craned_meta.static_meta.hostname);
         }
       } else {
         if (craned_meta.alive) {
-          if (request->query_down_nodes() &&
+          if (request.query_down_nodes() &&
               part_meta.partition_global_meta.alive_craned_cnt > 0)
             continue;
           if (alloc_res_in_use.cpu_count == 0 &&
@@ -540,7 +540,7 @@ CranedMetaContainerSimpleImpl::QueryClusterInfo(
             mix_craned_name_list.emplace_back(craned_meta.static_meta.hostname);
           }
         } else {
-          if (request->query_responding_nodes()) continue;
+          if (request.query_responding_nodes()) continue;
           down_craned_list->set_craned_num(down_craned_list->craned_num() + 1);
           down_craned_name_list.emplace_back(craned_meta.static_meta.hostname);
         }

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -540,9 +540,7 @@ CranedMetaContainerSimpleImpl::QueryClusterInfo(
             mix_craned_name_list.emplace_back(craned_meta.static_meta.hostname);
           }
         } else {
-          if (request->query_responding_nodes() &&
-              part_meta.partition_global_meta.alive_craned_cnt <= 0)
-            continue;
+          if (request->query_responding_nodes()) continue;
           down_craned_list->set_craned_num(down_craned_list->craned_num() + 1);
           down_craned_name_list.emplace_back(craned_meta.static_meta.hostname);
         }

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -488,7 +488,8 @@ CranedMetaContainerSimpleImpl::QueryClusterInfo(
           if (alloc_res_in_use.cpu_count == 0 &&
               alloc_res_in_use.memory_bytes == 0) {
             if (std::find(request.states().begin(), request.states().end(),
-                          0) == request.states().end())
+                          crane::grpc::CranedState::CRANE_IDLE) ==
+                request.states().end())
               continue;
             idle_craned_list->set_craned_num(idle_craned_list->craned_num() +
                                              1);
@@ -497,7 +498,8 @@ CranedMetaContainerSimpleImpl::QueryClusterInfo(
           } else if (alloc_res_avail.cpu_count == 0 &&
                      alloc_res_avail.memory_bytes == 0) {
             if (std::find(request.states().begin(), request.states().end(),
-                          2) == request.states().end())
+                          crane::grpc::CranedState::CRANE_ALLOC) ==
+                request.states().end())
               continue;
             alloc_craned_list->set_craned_num(alloc_craned_list->craned_num() +
                                               1);
@@ -505,14 +507,16 @@ CranedMetaContainerSimpleImpl::QueryClusterInfo(
                 craned_meta.static_meta.hostname);
           } else {
             if (std::find(request.states().begin(), request.states().end(),
-                          1) == request.states().end())
+                          crane::grpc::CranedState::CRANE_MIX) ==
+                request.states().end())
               continue;
             mix_craned_list->set_craned_num(mix_craned_list->craned_num() + 1);
             mix_craned_name_list.emplace_back(craned_meta.static_meta.hostname);
           }
         } else {
           if (request.query_responding_nodes()) continue;
-          if (std::find(request.states().begin(), request.states().end(), 3) ==
+          if (std::find(request.states().begin(), request.states().end(),
+                        crane::grpc::CranedState::CRANE_DOWN) ==
               request.states().end())
             continue;
           down_craned_list->set_craned_num(down_craned_list->craned_num() + 1);

--- a/src/CraneCtld/CranedMetaContainer.h
+++ b/src/CraneCtld/CranedMetaContainer.h
@@ -51,7 +51,8 @@ class CranedMetaContainerInterface {
   virtual crane::grpc::QueryPartitionInfoReply QueryPartitionInfo(
       const std::string& partition_name) = 0;
 
-  virtual crane::grpc::QueryClusterInfoReply QueryClusterInfo() = 0;
+  virtual crane::grpc::QueryClusterInfoReply QueryClusterInfo(
+      const crane::grpc::QueryClusterInfoRequest* request) = 0;
 
   virtual bool GetCraneId(const std::string& hostname, CranedId* node_id) = 0;
 
@@ -101,7 +102,8 @@ class CranedMetaContainerSimpleImpl final
   crane::grpc::QueryPartitionInfoReply QueryPartitionInfo(
       const std::string& partition_name) override;
 
-  crane::grpc::QueryClusterInfoReply QueryClusterInfo() override;
+  crane::grpc::QueryClusterInfoReply QueryClusterInfo(
+      const crane::grpc::QueryClusterInfoRequest* request) override;
 
   bool GetCraneId(const std::string& hostname, CranedId* craned_id) override;
 

--- a/src/CraneCtld/CranedMetaContainer.h
+++ b/src/CraneCtld/CranedMetaContainer.h
@@ -52,7 +52,7 @@ class CranedMetaContainerInterface {
       const std::string& partition_name) = 0;
 
   virtual crane::grpc::QueryClusterInfoReply QueryClusterInfo(
-      const crane::grpc::QueryClusterInfoRequest* request) = 0;
+      const crane::grpc::QueryClusterInfoRequest& request) = 0;
 
   virtual bool GetCraneId(const std::string& hostname, CranedId* node_id) = 0;
 
@@ -103,7 +103,7 @@ class CranedMetaContainerSimpleImpl final
       const std::string& partition_name) override;
 
   crane::grpc::QueryClusterInfoReply QueryClusterInfo(
-      const crane::grpc::QueryClusterInfoRequest* request) override;
+      const crane::grpc::QueryClusterInfoRequest& request) override;
 
   bool GetCraneId(const std::string& hostname, CranedId* craned_id) override;
 

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -758,7 +758,7 @@ grpc::Status CraneCtldServiceImpl::QueryClusterInfo(
     grpc::ServerContext *context,
     const crane::grpc::QueryClusterInfoRequest *request,
     crane::grpc::QueryClusterInfoReply *response) {
-  *response = g_meta_container->QueryClusterInfo(request);
+  *response = g_meta_container->QueryClusterInfo(*request);
   return grpc::Status::OK;
 }
 


### PR DESCRIPTION
cqueue：
--noheader 输出时不显示表头
--iterate 间隔指定秒刷新输出
--format 格式化输出
--taskId 过滤taskid，可以有多个，逗号隔开
--partiton 过滤partition，可以有多个，逗号隔开
--states 过滤state
--taskName 过滤taskName，可以有多个，逗号隔开
cinfo:
--dead 显示宕机或无响应节点（partition为down或者node状态为down）
--responding 显示响应的节点（只显示idle，mix，alloc的节点）
--nodes 过滤节点名，可以有多个，逗号隔开
--partition 过滤分区名，可以有多个，逗号隔开
--states 过滤节点状态，可以有多个，逗号隔开
修改：改变量名、state类型。