### PR TITLE
Dev/cqueue flags

### DIFF
--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -371,9 +371,14 @@ message QueryClusterInfoReply {
 }
 
 message QueryTasksInfoRequest{
-  int32 task_id = 1;
-  string partition = 2;
+  repeated uint32 filter_task_ids = 1;
+  repeated string filter_partitions = 2;
   int32 num_limit = 3;
+  repeated string filter_task_names = 4;
+  //repeated string filter_qos = 5;
+  repeated TaskStatus filter_task_states = 6;
+  repeated string filter_users = 7;
+  repeated string filter_accounts = 8;
 }
 
 message QueryTasksInfoReply{

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -377,12 +377,14 @@ message QueryTasksInfoRequest{
   int32 num_limit = 3;
   repeated string filter_task_names = 4;
   //repeated string filter_qos = 5;
+
   repeated TaskStatus filter_task_states = 6;
   repeated string filter_users = 7;
   repeated string filter_accounts = 8;
   google.protobuf.Timestamp filter_start_time = 9;
   google.protobuf.Timestamp filter_end_time = 10;
-  bool query_all = 11;
+
+  bool option_include_completed_tasks = 11;
 }
 
 message QueryTasksInfoReply{

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -4,6 +4,7 @@ package crane.grpc;
 option go_package = "/protos";
 
 import "PublicDefs.proto";
+import "google/protobuf/timestamp.proto";
 
 message Negotiation {
   uint32 version = 1;
@@ -379,7 +380,9 @@ message QueryTasksInfoRequest{
   repeated TaskStatus filter_task_states = 6;
   repeated string filter_users = 7;
   repeated string filter_accounts = 8;
-  bool query_all = 9;
+  google.protobuf.Timestamp filter_start_time = 9;
+  google.protobuf.Timestamp filter_end_time = 10;
+  bool query_all = 11;
 }
 
 message QueryTasksInfoReply{

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -379,6 +379,7 @@ message QueryTasksInfoRequest{
   repeated TaskStatus filter_task_states = 6;
   repeated string filter_users = 7;
   repeated string filter_accounts = 8;
+  bool query_all = 9;
 }
 
 message QueryTasksInfoReply{

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -161,6 +161,7 @@ message TaskInfo {
   uint32 node_num = 11;
   string cmd_line = 12;
   string cwd = 13;
+  string user_name = 14;
 
   // Dynamic task information
   TaskStatus status = 31;

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -94,6 +94,7 @@ message PersistedPartOfTaskInCtld {
   int64 task_db_id = 3;
   int32 gid = 4;
   string account = 5;
+  string username = 6;
 
   // Fields that will change after this task is accepted.
   int32 requeue_count = 11;

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -162,7 +162,7 @@ message TaskInfo {
   uint32 node_num = 11;
   string cmd_line = 12;
   string cwd = 13;
-  string user_name = 14;
+  string username = 14;
 
   // Dynamic task information
   TaskStatus status = 31;

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -60,20 +60,19 @@ grpc::Status CraneCtldServiceImpl::SubmitBatchTask(
 
   {  // Limit the lifecycle of user_scoped_ptr
     auto user_scoped_ptr =
-        g_account_manager->GetExistedUserInfo(task->password_entry->Username());
+        g_account_manager->GetExistedUserInfo(task->Username());
     if (!user_scoped_ptr) {
       response->set_ok(false);
-      response->set_reason(
-          fmt::format("User '{}' not found in the account database",
-                      task->password_entry->Username()));
+      response->set_reason(fmt::format(
+          "User '{}' not found in the account database", task->Username()));
       return grpc::Status::OK;
     }
 
     task->SetAccount(user_scoped_ptr->account);
   }
 
-  if (!g_account_manager->CheckUserPermissionToPartition(
-          task->password_entry->Username(), task->partition_id)) {
+  if (!g_account_manager->CheckUserPermissionToPartition(task->Username(),
+                                                         task->partition_id)) {
     response->set_ok(false);
     response->set_reason(fmt::format(
         "The user:{} don't have access to submit task in partition:{}",
@@ -82,8 +81,8 @@ grpc::Status CraneCtldServiceImpl::SubmitBatchTask(
   }
 
   AccountManager::Result check_qos_result =
-      g_account_manager->CheckAndApplyQosLimitOnTask(
-          task->password_entry->Username(), task.get());
+      g_account_manager->CheckAndApplyQosLimitOnTask(task->Username(),
+                                                     task.get());
   if (!check_qos_result.ok) {
     response->set_ok(false);
     response->set_reason(check_qos_result.reason);

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -264,7 +264,7 @@ grpc::Status CraneCtldServiceImpl::QueryTasksInfo(
     bool filter_end_time =
         no_end_time_constraint ||
         task.persisted_part().end_time() <= request->filter_end_time();
-    return filter_start_time || filter_end_time;
+    return filter_start_time && filter_end_time;
   };
 
   bool no_accounts_constraint = request->filter_accounts().empty();
@@ -385,7 +385,7 @@ grpc::Status CraneCtldServiceImpl::QueryTasksInfo(
     bool filter_end_time =
         no_end_time_constraint ||
         task.PersistedPart().end_time() <= request->filter_end_time();
-    return filter_start_time || filter_end_time;
+    return filter_start_time && filter_end_time;
   };
   auto db_task_rng_filter_account = [&](TaskInCtld &task) {
     return no_accounts_constraint || req_accounts.contains(task.Account());

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -318,15 +318,15 @@ grpc::Status CraneCtldServiceImpl::QueryTasksInfo(
       ranges::views::filter([&](crane::grpc::TaskInEmbeddedDb &task) -> bool {
         return task.persisted_part().status() == crane::grpc::Cancelled;
       });
-  auto filtered_ended_rng =
-      ended_rng | ranges::views::filter(task_rng_filter_account) |
-      ranges::views::filter(task_rng_filter_task_name) |
-      ranges::views::filter(task_rng_filter_username) |
-      ranges::views::filter(task_rng_filter_partition) |
-      ranges::views::filter(task_rng_filter_id) |
-      ranges::views::filter(task_rng_filter_state) |
-      ranges::views::filter(task_rng_filter_time) | ranges::views::reverse |
-      ranges::views::take(num_limit - task_list->size());
+  auto filtered_ended_rng = ended_rng |
+                            ranges::views::filter(task_rng_filter_account) |
+                            ranges::views::filter(task_rng_filter_task_name) |
+                            ranges::views::filter(task_rng_filter_username) |
+                            ranges::views::filter(task_rng_filter_partition) |
+                            ranges::views::filter(task_rng_filter_id) |
+                            ranges::views::filter(task_rng_filter_state) |
+                            ranges::views::filter(task_rng_filter_time) |
+                            ranges::views::take(num_limit - task_list->size());
   ranges::for_each(filtered_ended_rng, ended_append_fn);
 
   if (task_list->size() >= num_limit ||

--- a/src/CraneCtld/CtldPreCompiledHeader.h
+++ b/src/CraneCtld/CtldPreCompiledHeader.h
@@ -60,5 +60,6 @@
 #include "crane/Logger.h"
 // Logger.h must be the first
 
+#include "crane/PasswordEntry.h"
 #include "crane/PublicHeader.h"
 #include "crane/String.h"

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -164,6 +164,7 @@ struct TaskInCtld {
   task_db_id_t task_db_id;
   gid_t gid;
   std::string account;
+  std::string username;
 
   /* ----------- [3] ----------------
    * Fields that may change at run time.
@@ -196,6 +197,8 @@ struct TaskInCtld {
                                  // node id.
   std::string allocated_craneds_regex;
 
+  std::unique_ptr<PasswordEntry> password_entry;
+
   // Helper function
  public:
   crane::grpc::TaskToCtld const& TaskToCtld() { return task_to_ctld; }
@@ -226,6 +229,12 @@ struct TaskInCtld {
     persisted_part.set_account(val);
   }
   std::string const& Account() const { return account; }
+
+  void SetUsername(std::string const& val) {
+    username = val;
+    persisted_part.set_username(val);
+  }
+  std::string const& Username() const { return username; }
 
   void SetCranedIds(std::list<CranedId>&& val) {
     persisted_part.mutable_craned_ids()->Assign(val.begin(), val.end());
@@ -298,6 +307,8 @@ struct TaskInCtld {
     cpus_per_task = val.cpus_per_task();
 
     uid = val.uid();
+    password_entry = std::make_unique<PasswordEntry>(uid);
+
     name = val.name();
     cmd_line = val.cmd_line();
     env = val.env();
@@ -311,6 +322,8 @@ struct TaskInCtld {
     task_id = persisted_part.task_id();
     task_db_id = persisted_part.task_db_id();
     gid = persisted_part.gid();
+    account = persisted_part.account();
+    username = persisted_part.username();
 
     craned_ids.assign(persisted_part.craned_ids().begin(),
                       persisted_part.craned_ids().end());

--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -1,7 +1,6 @@
 #include "TaskScheduler.h"
 
 #include <google/protobuf/util/time_util.h>
-#include <pwd.h>
 
 #include "CranedKeeper.h"
 #include "CtldGrpcServer.h"
@@ -770,7 +769,7 @@ void MinLoadFirst::CalculateNodeSelectionInfoOfPartition_(
   for (const auto& craned_id : partition_metas.craned_ids) {
     CranedMeta const& craned_meta = craned_meta_map.at(craned_id);
 
-    // A offline craned shouldn't be scheduled.
+    // An offline craned shouldn't be scheduled.
     if (!craned_meta.alive) continue;
 
     // Sort all running task in this node by ending time.
@@ -1406,7 +1405,7 @@ void MinLoadFirst::SubtractTaskResourceNodeSelectionInfo_(
       // end at time x-2, If "x+2" lies in the interval [x, y-1) in
       // time__avail_res__map,
       //  for example, x+2 in [x, y-1) with the available resources amount
-      //  a, we need to divide this interval into to two intervals: [x,
+      //  `a`, we need to divide this interval into to two intervals: [x,
       //  x+2]: a-k, where k is the resource amount that task requires,
       //  [x+3, y-1]: a
       // Therefore, we need to insert a key-value at x+3 to preserve this.

--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -664,7 +664,7 @@ void TaskScheduler::QueryTasksInRam(
     task_it->set_node_num(task.TaskToCtld().node_num());
     task_it->set_cmd_line(task.TaskToCtld().cmd_line());
     task_it->set_cwd(task.TaskToCtld().cwd());
-    task_it->set_user_name(task.Username());
+    task_it->set_username(task.Username());
 
     task_it->set_alloc_cpus(task.resources.allocatable_resource.cpu_count);
     task_it->set_exit_code(0);

--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -664,8 +664,7 @@ void TaskScheduler::QueryTasksInRam(
     task_it->set_node_num(task.TaskToCtld().node_num());
     task_it->set_cmd_line(task.TaskToCtld().cmd_line());
     task_it->set_cwd(task.TaskToCtld().cwd());
-    struct passwd* pw = getpwuid(task.TaskToCtld().uid());
-    task_it->set_user_name(pw->pw_name);
+    task_it->set_user_name(task.Username());
 
     task_it->set_alloc_cpus(task.resources.allocatable_resource.cpu_count);
     task_it->set_exit_code(0);
@@ -696,13 +695,12 @@ void TaskScheduler::QueryTasksInRam(
     return no_accounts_constraint || req_accounts.contains(task.Account());
   };
 
-  bool no_users_constraint = request->filter_users().empty();
+  bool no_username_constraint = request->filter_users().empty();
   std::unordered_set<std::string> req_users(request->filter_users().begin(),
                                             request->filter_users().end());
-  auto task_rng_filter_user = [&](auto& it) {
+  auto task_rng_filter_username = [&](auto& it) {
     TaskInCtld& task = *it.second;
-    struct passwd* pw = getpwuid(task.uid);
-    return no_users_constraint || req_users.contains(pw->pw_name);
+    return no_username_constraint || req_users.contains(task.Username());
   };
 
   bool no_task_names_constraint = request->filter_task_names().empty();
@@ -753,7 +751,7 @@ void TaskScheduler::QueryTasksInRam(
                       ranges::views::filter(task_rng_filter_partition) |
                       ranges::views::filter(task_rng_filter_id) |
                       ranges::views::filter(task_rng_filter_state) |
-                      ranges::views::filter(task_rng_filter_user) |
+                      ranges::views::filter(task_rng_filter_username) |
                       ranges::views::filter(task_rng_filter_time) |
                       ranges::views::take(num_limit);
 

--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -685,7 +685,7 @@ void TaskScheduler::QueryTasksInRam(
     bool filter_end_time =
         no_end_time_constraint ||
         task.PersistedPart().end_time() <= request->filter_end_time();
-    return filter_start_time || filter_end_time;
+    return filter_start_time && filter_end_time;
   };
 
   bool no_accounts_constraint = request->filter_accounts().empty();


### PR DESCRIPTION
1.  cqueue -N/--noHeader 输出不显示表头
2.  cqueue -S/--start 显示开始时间 
3.  cqueue -j/--job 查询时过滤作业号
4. cqueue -n/--name 查询时过滤作业名
5. cqueue -i/--iterate 间隔输出，以秒为单位
6. cqueue -t/--states 查询时过滤作业状态
7. cqueue -p/--partition 查询时过滤分区名
8. cqueue -A/--account 查询时过滤账户名
9. cqueue -u/--user 查询时过滤用户名
10. 默认输出时显示pending、running、completing、cancelled作业
